### PR TITLE
fix: resolve image display failures in media proxy and pipeline

### DIFF
--- a/src/app/m/[publicId]/route.ts
+++ b/src/app/m/[publicId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getSignedUrl, toFetchableUrl } from '@/lib/storage'
+import { getSignedObjectUrl } from '@/lib/storage'
 import { getMediaObjectByPublicId } from '@/lib/media/service'
 
 export const runtime = 'nodejs'
@@ -40,7 +40,7 @@ export async function GET(
     })
   }
 
-  const fetchUrl = toFetchableUrl(getSignedUrl(media.storageKey))
+  const fetchUrl = await getSignedObjectUrl(media.storageKey)
   const range = request.headers.get('range')
 
   const upstream = await fetch(fetchUrl, {

--- a/src/lib/agent-pipeline/graph/nodes/art-director.ts
+++ b/src/lib/agent-pipeline/graph/nodes/art-director.ts
@@ -44,7 +44,31 @@ export async function runArtDirectorAgent(
   state.styleProfile = styleProfile
   await log(`风格配置: ${novelData.artStyle || 'default'}`)
 
-  // Step 2: Generate character images
+  // Step 2a: Ensure character appearances exist (generate visual profiles)
+  const unconfirmedChars = await prisma.novelPromotionCharacter.findMany({
+    where: {
+      novelPromotionProjectId: novelData.id,
+      profileConfirmed: false,
+      profileData: { not: null },
+    },
+    select: { id: true, name: true },
+  })
+  if (unconfirmedChars.length > 0) {
+    await log(`为 ${unconfirmedChars.length} 个角色生成视觉描述`)
+    const profileResult = await submitTask({
+      userId: state.userId,
+      locale: 'zh',
+      projectId: state.projectId,
+      type: TASK_TYPE.CHARACTER_PROFILE_BATCH_CONFIRM,
+      targetType: 'NovelPromotionProject',
+      targetId: novelData.id,
+      payload: { pipelineRunId: state.pipelineRunId },
+    })
+    await waitForMultipleTasksCompletion([profileResult.taskId], state.projectId)
+    await log('角色视觉描述生成完成')
+  }
+
+  // Step 2b: Generate character images
   const characters = await getCharacterAssets(novelData.id)
   const charsToGenerate = characters.filter((c) => !c.imageUrl)
   await log(`准备生成 ${charsToGenerate.length} 个角色图片 (image_character)`)

--- a/src/lib/agent-pipeline/graph/nodes/script-agent.ts
+++ b/src/lib/agent-pipeline/graph/nodes/script-agent.ts
@@ -61,15 +61,15 @@ export async function runScriptAgent(
 
   await log(`提取到 ${characters.length} 个角色、${locations.length} 个场景`)
 
-  // Step 4: Auto-generate promptFragments from appearance descriptions
+  // Step 4: Auto-generate promptFragments from appearance descriptions (skip locked assets)
   for (const char of characters) {
     const desc = char.appearances[0]?.description
-    if (desc && !char.promptFragment) {
+    if (desc && !char.promptFragment && char.assetStatus !== 'locked') {
       await updatePromptFragment('character', char.id, desc)
     }
   }
   for (const loc of locations) {
-    if (loc.summary && !loc.promptFragment) {
+    if (loc.summary && !loc.promptFragment && loc.assetStatus !== 'locked') {
       await updatePromptFragment('location', loc.id, loc.summary)
     }
   }

--- a/src/lib/media/outbound-image.ts
+++ b/src/lib/media/outbound-image.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { createScopedLogger } from '@/lib/logging/core'
 import { resolveStorageKeyFromMediaValue } from '@/lib/media/service'
 
-type StorageHelpers = Pick<typeof import('@/lib/storage'), 'getSignedUrl' | 'toFetchableUrl'>
+type StorageHelpers = Pick<typeof import('@/lib/storage'), 'getSignedUrl' | 'getSignedObjectUrl' | 'toFetchableUrl'>
 
 type InputIssueReason =
   | 'next_image_unwrapped'
@@ -89,6 +89,7 @@ async function getStorageHelpers(): Promise<StorageHelpers> {
   if (!storageHelpersPromise) {
     storageHelpersPromise = import('@/lib/storage').then((mod) => ({
       getSignedUrl: mod.getSignedUrl,
+      getSignedObjectUrl: mod.getSignedObjectUrl,
       toFetchableUrl: mod.toFetchableUrl,
     }))
   }
@@ -165,16 +166,17 @@ function toUrlMaybe(value: string): URL | null {
 
 function guessContentType(input: string, contentTypeHeader: string | null): string {
   const headerType = contentTypeHeader?.split(';')[0]?.trim()
-  if (headerType) return headerType
+  // Ignore generic octet-stream — fall through to extension-based lookup
+  if (headerType && headerType !== DEFAULT_CONTENT_TYPE) return headerType
   const parsed = toUrlMaybe(input)
   const pathname = parsed?.pathname ?? input
   const ext = path.extname(pathname).toLowerCase()
-  return MIME_BY_EXT[ext] || DEFAULT_CONTENT_TYPE
+  return MIME_BY_EXT[ext] || headerType || DEFAULT_CONTENT_TYPE
 }
 
 async function signStorageKey(storageKey: string): Promise<string> {
-  const { getSignedUrl, toFetchableUrl } = await getStorageHelpers()
-  return toFetchableUrl(getSignedUrl(storageKey, SIGNED_URL_TTL_SECONDS))
+  const { getSignedObjectUrl } = await getStorageHelpers()
+  return await getSignedObjectUrl(storageKey, SIGNED_URL_TTL_SECONDS)
 }
 
 async function toFetchableAbsoluteUrl(value: string): Promise<string> {

--- a/src/lib/workers/handlers/image-task-handler-shared.ts
+++ b/src/lib/workers/handlers/image-task-handler-shared.ts
@@ -187,8 +187,9 @@ export function findCharacterByName<T extends { name: string }>(characters: T[],
 export async function collectPanelReferenceImages(projectData: NovelProjectData, panel: PanelLike) {
   const refs: string[] = []
 
-  const sketch = toSignedUrlIfCos(panel.sketchImageUrl, 3600)
-  if (sketch) refs.push(sketch)
+  // Pass raw storage keys — normalizeReferenceImagesForGeneration handles signing
+  // via getSignedObjectUrl (direct MinIO presigned URLs that work in worker context)
+  if (panel.sketchImageUrl) refs.push(panel.sketchImageUrl)
 
   const panelCharacters = parsePanelCharacterReferences(panel.characters)
   for (const item of panelCharacters) {
@@ -208,8 +209,7 @@ export async function collectPanelReferenceImages(projectData: NovelProjectData,
     const selectedIndex = appearance.selectedIndex
     const selectedUrl = selectedIndex !== null && selectedIndex !== undefined ? imageUrls[selectedIndex] : null
     const key = selectedUrl || imageUrls[0] || appearance.imageUrl
-    const signed = toSignedUrlIfCos(key, 3600)
-    if (signed) refs.push(signed)
+    if (key) refs.push(key)
   }
 
   if (panel.location) {
@@ -217,8 +217,7 @@ export async function collectPanelReferenceImages(projectData: NovelProjectData,
     if (location) {
       const images = location.images || []
       const selected = images.find((img) => img.isSelected) || images[0]
-      const signed = toSignedUrlIfCos(selected?.imageUrl, 3600)
-      if (signed) refs.push(signed)
+      if (selected?.imageUrl) refs.push(selected.imageUrl)
     }
   }
 


### PR DESCRIPTION
## Summary

- **`/m/` 媒体代理路由修复**：将 `getSignedUrl` + `toFetchableUrl` 替换为 `getSignedObjectUrl`，解决 `NEXTAUTH_URL=https://localhost` 导致内部 fetch 失败的问题
- **MIME 类型检测修复**：`guessContentType` 跳过 `application/octet-stream`，改用扩展名推断（MinIO 返回通用 octet-stream 导致 ARK API 拒绝）
- **Worker 参考图片签名修复**：`collectPanelReferenceImages` 传递原始 storage key，由下游 `normalizeReferenceImagesForGeneration` 通过 `getSignedObjectUrl` 直接签名
- **Script Agent 锁定资产保护**：`updatePromptFragment` 调用前检查 `assetStatus !== 'locked'`，防止重跑 pipeline 时覆盖已锁定资产
- **Art Director 角色 Profile 步骤**：在图片生成前添加 `CHARACTER_PROFILE_BATCH_CONFIRM` 步骤

## Test plan

- [x] `/m/` 路由返回 200（面板图片、角色图片、场景图片）
- [x] Pipeline 完整运行 5 次迭代后成功（54 个任务全部完成）
- [ ] 前端切换手动模式后分镜图片和角色资产图片正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)