### PR TITLE
feat: Agent 透明化、Pipeline 断点续跑与顶部栏重构

### DIFF
--- a/messages/en/pipeline.json
+++ b/messages/en/pipeline.json
@@ -16,6 +16,8 @@
   "agentMode": "Agent Mode",
   "manualMode": "Manual Mode",
   "startPipeline": "Start Pipeline",
+  "retryPipeline": "Retry Pipeline",
+  "retryHint": "Resume from failure point",
   "cancelPipeline": "Cancel",
   "workflow": "Workflow",
   "currentActivity": "Current Task",

--- a/messages/zh/pipeline.json
+++ b/messages/zh/pipeline.json
@@ -16,6 +16,8 @@
   "agentMode": "Agent 模式",
   "manualMode": "手动模式",
   "startPipeline": "启动 Pipeline",
+  "retryPipeline": "重试 Pipeline",
+  "retryHint": "从失败位置继续执行",
   "cancelPipeline": "取消",
   "workflow": "工作流",
   "currentActivity": "当前任务",

--- a/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/WorkspaceHeaderShell.tsx
+++ b/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/WorkspaceHeaderShell.tsx
@@ -159,34 +159,6 @@ export default function WorkspaceHeaderShell({
         text={globalAssetText}
         onChange={(value) => { onUpdateConfig('globalAssetText', value) }}
       />
-      {episodes.length > 0 && currentEpisodeId && (() => {
-        const getNum = (name: string) => { const m = name.match(/\d+/); return m ? parseInt(m[0], 10) : Infinity }
-        const sorted = [...episodes].sort((a, b) => {
-          const d = getNum(a.name) - getNum(b.name)
-          return d !== 0 ? d : a.name.localeCompare(b.name, 'zh')
-        })
-        return (
-          <EpisodeSelector
-            projectName={projectName}
-            episodes={sorted.map((ep) => ({
-              id: ep.id,
-              title: ep.name,
-              summary: ep.description ?? undefined,
-              status: {
-                script: ep.clips?.length ? 'ready' as const : 'empty' as const,
-                visual: ep.storyboards?.some((sb) => sb.panels?.some((panel) => panel.videoUrl)) ? 'ready' as const : 'empty' as const,
-              },
-            }))}
-            currentId={currentEpisodeId}
-            onSelect={(id) => onEpisodeSelect?.(id)}
-            onAdd={onEpisodeCreate}
-            onRename={(id, newName) => onEpisodeRename?.(id, newName)}
-            onDelete={onEpisodeDelete}
-          />
-        )
-      })()}
-
-
 
       {!hideCapsuleNav && (
         <CapsuleNav
@@ -206,6 +178,33 @@ export default function WorkspaceHeaderShell({
         settingsLabel={settingsLabel}
         refreshTitle={refreshTitle}
         headerSlot={headerSlot}
+        episodeSlot={episodes.length > 0 && currentEpisodeId ? (() => {
+          const getNum = (name: string) => { const m = name.match(/\d+/); return m ? parseInt(m[0], 10) : Infinity }
+          const sorted = [...episodes].sort((a, b) => {
+            const d = getNum(a.name) - getNum(b.name)
+            return d !== 0 ? d : a.name.localeCompare(b.name, 'zh')
+          })
+          return (
+            <EpisodeSelector
+              projectName={projectName}
+              episodes={sorted.map((ep) => ({
+                id: ep.id,
+                title: ep.name,
+                summary: ep.description ?? undefined,
+                status: {
+                  script: ep.clips?.length ? 'ready' as const : 'empty' as const,
+                  visual: ep.storyboards?.some((sb) => sb.panels?.some((panel) => panel.videoUrl)) ? 'ready' as const : 'empty' as const,
+                },
+              }))}
+              currentId={currentEpisodeId}
+              onSelect={(id) => onEpisodeSelect?.(id)}
+              onAdd={onEpisodeCreate}
+              onRename={(id, newName) => onEpisodeRename?.(id, newName)}
+              onDelete={onEpisodeDelete}
+              inline
+            />
+          )
+        })() : undefined}
       />
     </>
   )

--- a/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/WorkspaceTopActions.tsx
+++ b/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/WorkspaceTopActions.tsx
@@ -1,8 +1,12 @@
 'use client'
 
 import { useCallback, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { useTranslations } from 'next-intl'
+import { Link } from '@/i18n/navigation'
 import { AppIcon } from '@/components/ui/icons'
 import { useToast } from '@/contexts/ToastContext'
+import LanguageSwitcher from '@/components/LanguageSwitcher'
 
 interface WorkspaceTopActionsProps {
   onOpenAssetLibrary: () => void
@@ -12,6 +16,7 @@ interface WorkspaceTopActionsProps {
   settingsLabel: string
   refreshTitle: string
   headerSlot?: React.ReactNode
+  episodeSlot?: React.ReactNode
 }
 
 export default function WorkspaceTopActions({
@@ -22,9 +27,12 @@ export default function WorkspaceTopActions({
   settingsLabel,
   refreshTitle,
   headerSlot,
+  episodeSlot,
 }: WorkspaceTopActionsProps) {
   const [isRefreshing, setIsRefreshing] = useState(false)
   const { showToast } = useToast()
+  const { data: session } = useSession()
+  const t = useTranslations('nav')
 
   const handleRefreshClick = useCallback(async () => {
     if (isRefreshing) {
@@ -36,7 +44,6 @@ export default function WorkspaceTopActions({
       await Promise.resolve(onRefresh())
       showToast(refreshTitle, 'success', 2400)
     } catch (error) {
-      // 显式记录错误，保持“显式失败”原则，但不打断用户操作
       // eslint-disable-next-line no-console
       console.error('[WorkspaceTopActions] 刷新失败', error)
     } finally {
@@ -45,32 +52,77 @@ export default function WorkspaceTopActions({
   }, [isRefreshing, onRefresh, refreshTitle, showToast])
 
   return (
-    <div className="fixed top-4 right-6 z-40 flex items-center gap-3">
-      {headerSlot}
-      <button
-        onClick={onOpenAssetLibrary}
-        className="glass-btn-base glass-btn-secondary flex items-center gap-2 px-4 py-3 rounded-3xl text-[var(--glass-text-primary)]"
-      >
-        <AppIcon name="package" className="h-5 w-5" />
-        <span className="font-semibold text-sm hidden md:inline tracking-[0.01em]">{assetLibraryLabel}</span>
-      </button>
-      <button
-        onClick={onOpenSettings}
-        className="glass-btn-base glass-btn-secondary flex items-center gap-2 px-4 py-3 rounded-3xl text-[var(--glass-text-primary)]"
-      >
-        <AppIcon name="settingsHexMinor" className="h-5 w-5" />
-        <span className="font-semibold text-sm hidden md:inline tracking-[0.01em]">{settingsLabel}</span>
-      </button>
-      <button
-        onClick={handleRefreshClick}
-        className={`glass-btn-base glass-btn-secondary flex items-center gap-2 px-4 py-3 rounded-3xl text-[var(--glass-text-primary)] ${
-          isRefreshing ? 'opacity-60 cursor-wait' : ''
-        }`}
-        title={refreshTitle}
-        disabled={isRefreshing}
-      >
-        <AppIcon name="refresh" className={`w-5 h-5 ${isRefreshing ? 'animate-spin' : ''}`} />
-      </button>
+    <div className="fixed top-4 left-0 right-0 z-40 flex items-center justify-between px-6">
+      {/* Left: Logo + Episode + Nav */}
+      <div className="flex items-center gap-2">
+        <Link
+          href={{ pathname: session ? '/workspace' : '/' }}
+          className="glass-btn-base glass-btn-secondary flex items-center gap-2 px-3 py-3 rounded-3xl text-[var(--glass-text-primary)] group"
+        >
+          <AppIcon name="clapperboard" className="h-5 w-5 text-emerald-500 shrink-0 transition-transform group-hover:scale-110" />
+          <span className="font-bold text-sm tracking-tight">
+            Agent<span className="text-emerald-500">Cine</span>
+          </span>
+        </Link>
+
+        {episodeSlot}
+
+        {session && (
+          <>
+            <Link
+              href={{ pathname: '/workspace' }}
+              className="glass-btn-base glass-btn-secondary flex items-center gap-2 px-3 py-3 rounded-3xl text-[var(--glass-text-secondary)] hover:text-[var(--glass-text-primary)]"
+            >
+              <AppIcon name="monitor" className="h-4 w-4" />
+              <span className="text-sm font-medium">{t('workspace')}</span>
+            </Link>
+            <Link
+              href={{ pathname: '/workspace/asset-hub' }}
+              className="glass-btn-base glass-btn-secondary flex items-center gap-2 px-3 py-3 rounded-3xl text-[var(--glass-text-secondary)] hover:text-[var(--glass-text-primary)]"
+            >
+              <AppIcon name="folderHeart" className="h-4 w-4" />
+              <span className="text-sm font-medium">{t('assetHub')}</span>
+            </Link>
+            <Link
+              href={{ pathname: '/profile' }}
+              className="glass-btn-base glass-btn-secondary flex items-center gap-2 px-3 py-3 rounded-3xl text-[var(--glass-text-secondary)] hover:text-[var(--glass-text-primary)]"
+            >
+              <AppIcon name="userRoundCog" className="h-4 w-4" />
+              <span className="text-sm font-medium">{t('profile')}</span>
+            </Link>
+            <LanguageSwitcher />
+          </>
+        )}
+      </div>
+
+      {/* Right: Mode toggle + Asset Library + Settings + Refresh */}
+      <div className="flex items-center gap-3">
+        {headerSlot}
+        <button
+          onClick={onOpenAssetLibrary}
+          className="glass-btn-base glass-btn-secondary flex items-center gap-2 px-4 py-3 rounded-3xl text-[var(--glass-text-primary)]"
+        >
+          <AppIcon name="package" className="h-5 w-5" />
+          <span className="font-semibold text-sm hidden md:inline tracking-[0.01em]">{assetLibraryLabel}</span>
+        </button>
+        <button
+          onClick={onOpenSettings}
+          className="glass-btn-base glass-btn-secondary flex items-center gap-2 px-4 py-3 rounded-3xl text-[var(--glass-text-primary)]"
+        >
+          <AppIcon name="settingsHexMinor" className="h-5 w-5" />
+          <span className="font-semibold text-sm hidden md:inline tracking-[0.01em]">{settingsLabel}</span>
+        </button>
+        <button
+          onClick={handleRefreshClick}
+          className={`glass-btn-base glass-btn-secondary flex items-center gap-2 px-4 py-3 rounded-3xl text-[var(--glass-text-primary)] ${
+            isRefreshing ? 'opacity-60 cursor-wait' : ''
+          }`}
+          title={refreshTitle}
+          disabled={isRefreshing}
+        >
+          <AppIcon name="refresh" className={`w-5 h-5 ${isRefreshing ? 'animate-spin' : ''}`} />
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/WorkspaceTopActions.tsx
+++ b/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/WorkspaceTopActions.tsx
@@ -8,6 +8,8 @@ import { AppIcon } from '@/components/ui/icons'
 import { useToast } from '@/contexts/ToastContext'
 import LanguageSwitcher from '@/components/LanguageSwitcher'
 
+const BTN = 'flex items-center gap-2 h-10 px-3.5 rounded-2xl text-sm font-medium bg-gradient-to-br from-orange-50/80 to-amber-50/60 border border-orange-200/50 text-orange-900/80 backdrop-blur-md shadow-sm hover:from-orange-100/90 hover:to-amber-100/70 hover:border-orange-300/60 hover:text-orange-900 transition-all'
+
 interface WorkspaceTopActionsProps {
   onOpenAssetLibrary: () => void
   onOpenSettings: () => void
@@ -35,10 +37,7 @@ export default function WorkspaceTopActions({
   const t = useTranslations('nav')
 
   const handleRefreshClick = useCallback(async () => {
-    if (isRefreshing) {
-      return
-    }
-
+    if (isRefreshing) return
     try {
       setIsRefreshing(true)
       await Promise.resolve(onRefresh())
@@ -57,11 +56,11 @@ export default function WorkspaceTopActions({
       <div className="flex items-center gap-2">
         <Link
           href={{ pathname: session ? '/workspace' : '/' }}
-          className="glass-btn-base glass-btn-secondary flex items-center gap-2 px-3 py-3 rounded-3xl text-[var(--glass-text-primary)] group"
+          className={`${BTN} group`}
         >
-          <AppIcon name="clapperboard" className="h-5 w-5 text-emerald-500 shrink-0 transition-transform group-hover:scale-110" />
-          <span className="font-bold text-sm tracking-tight">
-            Agent<span className="text-emerald-500">Cine</span>
+          <AppIcon name="clapperboard" className="h-4 w-4 text-orange-600 shrink-0 transition-transform group-hover:scale-110" />
+          <span className="font-bold tracking-tight">
+            Agent<span className="text-orange-600">Cine</span>
           </span>
         </Link>
 
@@ -69,58 +68,41 @@ export default function WorkspaceTopActions({
 
         {session && (
           <>
-            <Link
-              href={{ pathname: '/workspace' }}
-              className="glass-btn-base glass-btn-secondary flex items-center gap-2 px-3 py-3 rounded-3xl text-[var(--glass-text-secondary)] hover:text-[var(--glass-text-primary)]"
-            >
+            <Link href={{ pathname: '/workspace' }} className={BTN}>
               <AppIcon name="monitor" className="h-4 w-4" />
-              <span className="text-sm font-medium">{t('workspace')}</span>
+              <span>{t('workspace')}</span>
             </Link>
-            <Link
-              href={{ pathname: '/workspace/asset-hub' }}
-              className="glass-btn-base glass-btn-secondary flex items-center gap-2 px-3 py-3 rounded-3xl text-[var(--glass-text-secondary)] hover:text-[var(--glass-text-primary)]"
-            >
+            <Link href={{ pathname: '/workspace/asset-hub' }} className={BTN}>
               <AppIcon name="folderHeart" className="h-4 w-4" />
-              <span className="text-sm font-medium">{t('assetHub')}</span>
+              <span>{t('assetHub')}</span>
             </Link>
-            <Link
-              href={{ pathname: '/profile' }}
-              className="glass-btn-base glass-btn-secondary flex items-center gap-2 px-3 py-3 rounded-3xl text-[var(--glass-text-secondary)] hover:text-[var(--glass-text-primary)]"
-            >
+            <Link href={{ pathname: '/profile' }} className={BTN}>
               <AppIcon name="userRoundCog" className="h-4 w-4" />
-              <span className="text-sm font-medium">{t('profile')}</span>
+              <span>{t('profile')}</span>
             </Link>
-            <LanguageSwitcher />
+            <LanguageSwitcher className={BTN} />
           </>
         )}
       </div>
 
       {/* Right: Mode toggle + Asset Library + Settings + Refresh */}
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-2">
         {headerSlot}
-        <button
-          onClick={onOpenAssetLibrary}
-          className="glass-btn-base glass-btn-secondary flex items-center gap-2 px-4 py-3 rounded-3xl text-[var(--glass-text-primary)]"
-        >
-          <AppIcon name="package" className="h-5 w-5" />
-          <span className="font-semibold text-sm hidden md:inline tracking-[0.01em]">{assetLibraryLabel}</span>
+        <button onClick={onOpenAssetLibrary} className={BTN}>
+          <AppIcon name="package" className="h-4 w-4" />
+          <span className="hidden md:inline">{assetLibraryLabel}</span>
         </button>
-        <button
-          onClick={onOpenSettings}
-          className="glass-btn-base glass-btn-secondary flex items-center gap-2 px-4 py-3 rounded-3xl text-[var(--glass-text-primary)]"
-        >
-          <AppIcon name="settingsHexMinor" className="h-5 w-5" />
-          <span className="font-semibold text-sm hidden md:inline tracking-[0.01em]">{settingsLabel}</span>
+        <button onClick={onOpenSettings} className={BTN}>
+          <AppIcon name="settingsHexMinor" className="h-4 w-4" />
+          <span className="hidden md:inline">{settingsLabel}</span>
         </button>
         <button
           onClick={handleRefreshClick}
-          className={`glass-btn-base glass-btn-secondary flex items-center gap-2 px-4 py-3 rounded-3xl text-[var(--glass-text-primary)] ${
-            isRefreshing ? 'opacity-60 cursor-wait' : ''
-          }`}
+          className={`${BTN} ${isRefreshing ? 'opacity-60 cursor-wait' : ''}`}
           title={refreshTitle}
           disabled={isRefreshing}
         >
-          <AppIcon name="refresh" className={`w-5 h-5 ${isRefreshing ? 'animate-spin' : ''}`} />
+          <AppIcon name="refresh" className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
         </button>
       </div>
     </div>

--- a/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/agent-pipeline/AgentPipelineDashboard.tsx
+++ b/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/agent-pipeline/AgentPipelineDashboard.tsx
@@ -46,6 +46,7 @@ export function AgentPipelineDashboard({
         novelText={novelText}
         disabled={disabled}
         pipelineStatus={data?.status}
+        errorMessage={data?.errorMessage}
         runId={data?.runId ?? null}
         onStarted={onStarted}
         onEnterEditor={onEnterEditor}

--- a/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/agent-pipeline/ExpandableStepCard.tsx
+++ b/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/agent-pipeline/ExpandableStepCard.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl'
 import { AppIcon } from '@/components/ui/icons'
 import { AgentCard } from './AgentCard'
 import { getAgentByStepKey } from '@/lib/agent-pipeline/agent-identities'
-import type { StepInfo, ActiveTaskInfo, PipelineLogEntry } from '../../hooks/usePipelineStatus'
+import type { StepInfo, ActiveTaskInfo, PipelineLogEntry, SubStepInfo } from '../../hooks/usePipelineStatus'
 import { TASK_TYPE_KEYS } from './constants'
 
 const fmt = new Intl.NumberFormat()
@@ -26,6 +26,49 @@ type Props = {
   isLast?: boolean
   activeTask?: ActiveTaskInfo | null
   logs?: PipelineLogEntry[]
+}
+
+function SubStepStatusIcon({ status }: { status: SubStepInfo['status'] }) {
+  switch (status) {
+    case 'running':
+      return <AppIcon name="loader" className="h-3 w-3 text-blue-400 animate-spin shrink-0" />
+    case 'completed':
+      return <AppIcon name="checkCircle" className="h-3 w-3 text-emerald-400 shrink-0" />
+    case 'failed':
+      return <AppIcon name="alertCircle" className="h-3 w-3 text-red-400 shrink-0" />
+    default:
+      return <div className="h-3 w-3 rounded-full border border-(--glass-stroke-base) shrink-0" />
+  }
+}
+
+function SubStepList({ subSteps }: { subSteps: SubStepInfo[] }) {
+  if (subSteps.length === 0) return null
+
+  return (
+    <div className="pt-2 space-y-1 px-1">
+      <div className="text-[10px] font-semibold uppercase tracking-wider text-(--glass-text-tertiary) mb-1">
+        Steps
+      </div>
+      <div className="space-y-0.5">
+        {subSteps.map((sub) => (
+          <div key={sub.key} className="flex items-center gap-2 py-0.5">
+            <SubStepStatusIcon status={sub.status} />
+            <span className={`text-xs ${
+              sub.status === 'pending'
+                ? 'text-(--glass-text-tertiary)'
+                : sub.status === 'running'
+                  ? 'text-(--glass-text-primary)'
+                  : sub.status === 'completed'
+                    ? 'text-(--glass-text-secondary)'
+                    : 'text-red-300'
+            }`}>
+              {sub.title}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
 }
 
 export function ExpandableStepCard({ step, isLast, activeTask, logs }: Props) {
@@ -149,6 +192,11 @@ export function ExpandableStepCard({ step, isLast, activeTask, logs }: Props) {
                   </div>
                 )}
               </div>
+            )}
+
+            {/* Sub-step progress */}
+            {step.subSteps && step.subSteps.length > 0 && (
+              <SubStepList subSteps={step.subSteps} />
             )}
 
             {/* Stats grid — for completed/failed steps */}

--- a/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/agent-pipeline/PipelineActionBar.tsx
+++ b/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/agent-pipeline/PipelineActionBar.tsx
@@ -333,15 +333,15 @@ export function PipelineActionBar({
       </div>
 
       {startMutation.isError && (
-        <div className="flex items-start gap-2 rounded-lg bg-red-900/30 border border-red-800 px-3 py-2 text-xs text-red-300">
-          <AppIcon name="alertCircle" className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+        <div className="flex items-start gap-2 rounded-lg bg-red-50 border border-red-200 px-3 py-2 text-xs text-red-700">
+          <AppIcon name="alertCircle" className="h-3.5 w-3.5 mt-0.5 shrink-0 text-red-500" />
           <span>{startMutation.error.message}</span>
         </div>
       )}
 
       {isFailed && errorMessage && (
-        <div className="flex items-start gap-2 rounded-lg bg-red-900/30 border border-red-800 px-3 py-2 text-xs text-red-300">
-          <AppIcon name="alertCircle" className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+        <div className="flex items-start gap-2 rounded-lg bg-red-50 border border-red-200 px-3 py-2 text-xs text-red-700">
+          <AppIcon name="alertCircle" className="h-3.5 w-3.5 mt-0.5 shrink-0 text-red-500" />
           <span className="break-all">{errorMessage}</span>
         </div>
       )}

--- a/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/agent-pipeline/PipelineActionBar.tsx
+++ b/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/agent-pipeline/PipelineActionBar.tsx
@@ -289,6 +289,16 @@ export function PipelineActionBar({
               </div>
             )}
           </div>
+        ) : isFailed ? (
+          <button
+            onClick={() => startMutation.mutate()}
+            disabled={!canStart}
+            title={t('retryHint')}
+            className="flex-1 flex items-center justify-center gap-2 rounded-lg bg-amber-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            <AppIcon name="refresh" className="h-4 w-4" />
+            {startMutation.isPending ? t('starting') : t('retryPipeline')}
+          </button>
         ) : !isRunning && !isPaused ? (
           <button
             onClick={() => startMutation.mutate()}

--- a/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/agent-pipeline/PipelineActionBar.tsx
+++ b/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/agent-pipeline/PipelineActionBar.tsx
@@ -12,6 +12,7 @@ type Props = {
   novelText: string
   disabled: boolean
   pipelineStatus?: string
+  errorMessage?: string | null
   runId: string | null
   onStarted: (pipelineRunId: string) => void
   onEnterEditor: () => void
@@ -65,6 +66,7 @@ export function PipelineActionBar({
   novelText,
   disabled,
   pipelineStatus,
+  errorMessage,
   runId,
   onStarted,
   onEnterEditor,
@@ -334,6 +336,13 @@ export function PipelineActionBar({
         <div className="flex items-start gap-2 rounded-lg bg-red-900/30 border border-red-800 px-3 py-2 text-xs text-red-300">
           <AppIcon name="alertCircle" className="h-3.5 w-3.5 mt-0.5 shrink-0" />
           <span>{startMutation.error.message}</span>
+        </div>
+      )}
+
+      {isFailed && errorMessage && (
+        <div className="flex items-start gap-2 rounded-lg bg-red-900/30 border border-red-800 px-3 py-2 text-xs text-red-300">
+          <AppIcon name="alertCircle" className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+          <span className="break-all">{errorMessage}</span>
         </div>
       )}
     </div>

--- a/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/agent-pipeline/WorkflowTimeline.tsx
+++ b/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/agent-pipeline/WorkflowTimeline.tsx
@@ -3,18 +3,30 @@
 import { useTranslations } from 'next-intl'
 import type { StepInfo, TokenUsage, ActiveTaskInfo, PipelineLogEntry } from '../../hooks/usePipelineStatus'
 import { ExpandableStepCard } from './ExpandableStepCard'
-import { getAgentByPhase } from '@/lib/agent-pipeline/agent-identities'
+import { getAgentByPhase, getAgentByStepKey } from '@/lib/agent-pipeline/agent-identities'
 
 const EMPTY_USAGE: TokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
 
+function buildDefaultSubSteps(stepKey: string) {
+  const identity = getAgentByStepKey(stepKey)
+  if (!identity) return []
+  return identity.subSteps.map((def) => ({
+    key: def.key,
+    title: def.titleFallback,
+    status: 'pending' as const,
+    startedAt: null,
+    completedAt: null,
+  }))
+}
+
 const DEFAULT_STEPS: StepInfo[] = [
-  { stepKey: 'script_agent', stepTitle: '', status: 'pending', stepIndex: 0, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: [] },
-  { stepKey: 'art_director_agent', stepTitle: '', status: 'pending', stepIndex: 1, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: [] },
-  { stepKey: 'storyboard_agent', stepTitle: '', status: 'pending', stepIndex: 2, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: [] },
-  { stepKey: 'producer_quality_check', stepTitle: '', status: 'pending', stepIndex: 3, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: [] },
-  { stepKey: 'video_generation_agent', stepTitle: '', status: 'pending', stepIndex: 4, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: [] },
-  { stepKey: 'voice_generation_agent', stepTitle: '', status: 'pending', stepIndex: 5, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: [] },
-  { stepKey: 'assembly_agent', stepTitle: '', status: 'pending', stepIndex: 6, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: [] },
+  { stepKey: 'script_agent', stepTitle: '', status: 'pending', stepIndex: 0, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: buildDefaultSubSteps('script_agent') },
+  { stepKey: 'art_director_agent', stepTitle: '', status: 'pending', stepIndex: 1, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: buildDefaultSubSteps('art_director_agent') },
+  { stepKey: 'storyboard_agent', stepTitle: '', status: 'pending', stepIndex: 2, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: buildDefaultSubSteps('storyboard_agent') },
+  { stepKey: 'producer_quality_check', stepTitle: '', status: 'pending', stepIndex: 3, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: buildDefaultSubSteps('producer_quality_check') },
+  { stepKey: 'video_generation_agent', stepTitle: '', status: 'pending', stepIndex: 4, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: buildDefaultSubSteps('video_generation_agent') },
+  { stepKey: 'voice_generation_agent', stepTitle: '', status: 'pending', stepIndex: 5, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: buildDefaultSubSteps('voice_generation_agent') },
+  { stepKey: 'assembly_agent', stepTitle: '', status: 'pending', stepIndex: 6, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: buildDefaultSubSteps('assembly_agent') },
 ]
 
 type Props = {

--- a/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/agent-pipeline/WorkflowTimeline.tsx
+++ b/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/components/agent-pipeline/WorkflowTimeline.tsx
@@ -8,13 +8,13 @@ import { getAgentByPhase } from '@/lib/agent-pipeline/agent-identities'
 const EMPTY_USAGE: TokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
 
 const DEFAULT_STEPS: StepInfo[] = [
-  { stepKey: 'script_agent', stepTitle: '', status: 'pending', stepIndex: 0, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE },
-  { stepKey: 'art_director_agent', stepTitle: '', status: 'pending', stepIndex: 1, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE },
-  { stepKey: 'storyboard_agent', stepTitle: '', status: 'pending', stepIndex: 2, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE },
-  { stepKey: 'producer_quality_check', stepTitle: '', status: 'pending', stepIndex: 3, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE },
-  { stepKey: 'video_generation_agent', stepTitle: '', status: 'pending', stepIndex: 4, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE },
-  { stepKey: 'voice_generation_agent', stepTitle: '', status: 'pending', stepIndex: 5, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE },
-  { stepKey: 'assembly_agent', stepTitle: '', status: 'pending', stepIndex: 6, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE },
+  { stepKey: 'script_agent', stepTitle: '', status: 'pending', stepIndex: 0, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: [] },
+  { stepKey: 'art_director_agent', stepTitle: '', status: 'pending', stepIndex: 1, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: [] },
+  { stepKey: 'storyboard_agent', stepTitle: '', status: 'pending', stepIndex: 2, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: [] },
+  { stepKey: 'producer_quality_check', stepTitle: '', status: 'pending', stepIndex: 3, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: [] },
+  { stepKey: 'video_generation_agent', stepTitle: '', status: 'pending', stepIndex: 4, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: [] },
+  { stepKey: 'voice_generation_agent', stepTitle: '', status: 'pending', stepIndex: 5, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: [] },
+  { stepKey: 'assembly_agent', stepTitle: '', status: 'pending', stepIndex: 6, startedAt: null, finishedAt: null, lastErrorMessage: null, usage: EMPTY_USAGE, subSteps: [] },
 ]
 
 type Props = {

--- a/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/hooks/usePipelineStatus.ts
+++ b/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/hooks/usePipelineStatus.ts
@@ -2,9 +2,9 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { queryKeys } from '@/lib/query/keys'
-import type { TokenUsage, StepInfo, ActiveTaskInfo, PipelineLogEntry } from '@/lib/agent-pipeline/pipeline-types'
+import type { TokenUsage, StepInfo, SubStepInfo, ActiveTaskInfo, PipelineLogEntry } from '@/lib/agent-pipeline/pipeline-types'
 
-export type { TokenUsage, StepInfo, ActiveTaskInfo, PipelineLogEntry }
+export type { TokenUsage, StepInfo, SubStepInfo, ActiveTaskInfo, PipelineLogEntry }
 
 export type ReviewSummary = {
   total: number

--- a/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/hooks/usePipelineStatus.ts
+++ b/src/app/[locale]/workspace/[projectId]/modes/novel-promotion/hooks/usePipelineStatus.ts
@@ -44,6 +44,7 @@ export function usePipelineStatus(projectId: string, enabled: boolean) {
       if (!data?.exists) return false
       const status = data.status
       if (status === 'completed' || status === 'failed') return false
+      if (status === 'paused') return 10000
       return 3000
     },
     enabled,

--- a/src/app/[locale]/workspace/[projectId]/page.tsx
+++ b/src/app/[locale]/workspace/[projectId]/page.tsx
@@ -371,7 +371,7 @@ export default function ProjectDetailPage() {
   }
 
   return (
-    <AppShell noWarmDecor noBokeh>
+    <AppShell noWarmDecor noBokeh hideSideNav>
 
       {/* V3 UI: 浮动导航替代了旧的 Sidebar */}
 

--- a/src/app/api/novel-promotion/[projectId]/pipeline/resume/route.ts
+++ b/src/app/api/novel-promotion/[projectId]/pipeline/resume/route.ts
@@ -3,6 +3,7 @@ import { requireProjectAuth, isErrorResponse } from '@/lib/api-auth'
 import { apiHandler, ApiError } from '@/lib/api-errors'
 import { prisma } from '@/lib/prisma'
 import { PIPELINE_STATUS } from '@/lib/agent-pipeline/types'
+import { resumePipeline } from '@/lib/agent-pipeline'
 
 export const POST = apiHandler(async (
   _request: NextRequest,
@@ -12,6 +13,7 @@ export const POST = apiHandler(async (
 
   const authResult = await requireProjectAuth(projectId)
   if (isErrorResponse(authResult)) return authResult
+  const { session } = authResult
 
   const pipelineRun = await prisma.pipelineRun.findFirst({
     where: { projectId },
@@ -26,10 +28,11 @@ export const POST = apiHandler(async (
     throw new ApiError('INVALID_PARAMS', { message: 'Pipeline is not paused' })
   }
 
-  await prisma.pipelineRun.update({
-    where: { id: pipelineRun.id },
-    data: { status: PIPELINE_STATUS.RUNNING },
+  const result = await resumePipeline({
+    userId: session.user.id,
+    projectId,
+    pipelineRunId: pipelineRun.id,
   })
 
-  return Response.json({ success: true })
+  return Response.json(result)
 })

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -12,16 +12,18 @@ interface AppShellProps {
   noWarmDecor?: boolean
   /** Skip bokeh orbs */
   noBokeh?: boolean
+  /** Hide the left SideNav and remove left padding */
+  hideSideNav?: boolean
 }
 
-export default function AppShell({ children, noWarmDecor, noBokeh }: AppShellProps) {
+export default function AppShell({ children, noWarmDecor, noBokeh, hideSideNav }: AppShellProps) {
   const tc = useTranslations('common')
   const { currentVersion, update, shouldPulse, showModal, openModal, dismissCurrentUpdate } = useGithubReleaseUpdate()
 
   return (
     <div className="glass-page min-h-screen overflow-x-hidden cinema-vignette cinema-grain">
       {/* Side Navigation */}
-      <SideNav />
+      {!hideSideNav && <SideNav />}
 
       {/* Background Decor */}
       {!noWarmDecor && <div className="cinema-bg-warm-decor" />}
@@ -54,7 +56,7 @@ export default function AppShell({ children, noWarmDecor, noBokeh }: AppShellPro
       </div>
 
       {/* Main Content */}
-      <main className="relative z-10 pl-20">
+      <main className={`relative z-10 ${hideSideNav ? '' : 'pl-20'}`}>
         {children}
       </main>
 

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -35,7 +35,7 @@ function isSupportedLocale(locale?: string): locale is Locale {
     return locale === 'zh' || locale === 'en'
 }
 
-export default function LanguageSwitcher() {
+export default function LanguageSwitcher({ className }: { className?: string }) {
     const router = useRouter()
     const pathname = usePathname()
     const locale = useLocale()
@@ -96,7 +96,7 @@ export default function LanguageSwitcher() {
                     onClick={() => setIsMenuOpen((prev) => !prev)}
                     aria-label={SWITCH_CONFIRM_COPY[targetLocale].triggerLabel}
                     aria-expanded={isMenuOpen}
-                    className="glass-btn-base glass-btn-secondary inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm"
+                    className={className || "glass-btn-base glass-btn-secondary inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm"}
                 >
                     <AppIcon name="globe" className="h-4 w-4" />
                     <span>{LANGUAGE_LABELS[currentLocale]}</span>

--- a/src/components/ui/CapsuleNav.tsx
+++ b/src/components/ui/CapsuleNav.tsx
@@ -220,22 +220,17 @@ export function EpisodeSelector({
         <div className={inline ? 'relative' : 'fixed top-4 left-6 z-[60]'} ref={menuRef}>
             <button
                 onClick={() => setIsOpen(!isOpen)}
-                className="glass-btn-base glass-btn-secondary flex items-center gap-3 px-4 py-3 transition-all group"
-                style={{ borderRadius: '1.5rem' }}
+                className="flex items-center gap-2 h-10 px-3.5 rounded-2xl text-sm font-medium bg-gradient-to-br from-orange-50/80 to-amber-50/60 border border-orange-200/50 text-orange-900/80 backdrop-blur-md shadow-sm hover:from-orange-100/90 hover:to-amber-100/70 hover:border-orange-300/60 hover:text-orange-900 transition-all"
             >
-                <div className="glass-surface-soft flex h-10 w-10 items-center justify-center rounded-xl text-xs font-bold text-[var(--glass-tone-info-fg)]">
-                    {t('episode')}
-                </div>
-                <div className="flex items-center gap-1.5 mr-2">
-                    <span className="text-sm font-bold text-[var(--glass-text-primary)] line-clamp-1 max-w-[160px]">
-                        {projectName || t('project')}
-                    </span>
-                    <span className="text-sm text-[var(--glass-text-tertiary)]">/</span>
-                    <span className="text-sm text-[var(--glass-text-secondary)] line-clamp-1 max-w-[160px]">
-                        {currentEp.title}
-                    </span>
-                </div>
-                <AppIcon name="chevronDown" className={`w-4 h-4 text-[var(--glass-text-tertiary)] transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+                <AppIcon name="film" className="h-4 w-4 text-orange-600 shrink-0" />
+                <span className="font-bold line-clamp-1 max-w-[120px]">
+                    {projectName || t('project')}
+                </span>
+                <span className="text-orange-400">/</span>
+                <span className="line-clamp-1 max-w-[120px]">
+                    {currentEp.title}
+                </span>
+                <AppIcon name="chevronDown" className={`w-3.5 h-3.5 text-orange-400 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
             </button>
 
             {isOpen && (

--- a/src/components/ui/CapsuleNav.tsx
+++ b/src/components/ui/CapsuleNav.tsx
@@ -226,10 +226,11 @@ export function EpisodeSelector({
                 <div className="glass-surface-soft flex h-10 w-10 items-center justify-center rounded-xl text-xs font-bold text-[var(--glass-tone-info-fg)]">
                     {t('episode')}
                 </div>
-                <div className="flex flex-col items-start text-left mr-2">
+                <div className="flex items-center gap-1.5 mr-2">
                     <span className="text-sm font-bold text-[var(--glass-text-primary)] line-clamp-1 max-w-[160px]">
                         {projectName || t('project')}
                     </span>
+                    <span className="text-sm text-[var(--glass-text-tertiary)]">/</span>
                     <span className="text-sm text-[var(--glass-text-secondary)] line-clamp-1 max-w-[160px]">
                         {currentEp.title}
                     </span>

--- a/src/components/ui/CapsuleNav.tsx
+++ b/src/components/ui/CapsuleNav.tsx
@@ -183,6 +183,7 @@ interface EpisodeSelectorProps {
     onRename?: (id: string, newName: string) => void
     onDelete?: (id: string) => void
     projectName?: string  // 项目名称，显示在左上角
+    inline?: boolean      // 内联模式，不使用 fixed 定位
 }
 
 export function EpisodeSelector({
@@ -192,7 +193,8 @@ export function EpisodeSelector({
     onAdd,
     onRename,
     onDelete,
-    projectName
+    projectName,
+    inline,
 }: EpisodeSelectorProps) {
     const t = useTranslations('common')
     const [isOpen, setIsOpen] = useState(false)
@@ -215,7 +217,7 @@ export function EpisodeSelector({
     if (!currentEp) return null
 
     return (
-        <div className="fixed top-4 left-6 z-[60]" ref={menuRef}>
+        <div className={inline ? 'relative' : 'fixed top-4 left-6 z-[60]'} ref={menuRef}>
             <button
                 onClick={() => setIsOpen(!isOpen)}
                 className="glass-btn-base glass-btn-secondary flex items-center gap-3 px-4 py-3 transition-all group"

--- a/src/lib/agent-pipeline/agent-identities.ts
+++ b/src/lib/agent-pipeline/agent-identities.ts
@@ -1,5 +1,14 @@
 import type { AppIconName } from '@/components/ui/icons/registry'
 
+export type AgentSubStep = {
+  /** Unique key within the agent */
+  key: string
+  /** i18n key under 'pipeline' namespace */
+  titleKey: string
+  /** Fallback title (Chinese) */
+  titleFallback: string
+}
+
 export type AgentIdentity = {
   /** Pipeline step key matching StepInfo.stepKey */
   stepKey: string
@@ -15,6 +24,8 @@ export type AgentIdentity = {
   nameKey: string
   /** i18n key for agent role description */
   roleKey: string
+  /** Ordered list of sub-steps for this agent */
+  subSteps: AgentSubStep[]
 }
 
 export const AGENT_IDENTITIES: AgentIdentity[] = [
@@ -26,6 +37,11 @@ export const AGENT_IDENTITIES: AgentIdentity[] = [
     accentColor: 'text-violet-400',
     nameKey: 'agentScript',
     roleKey: 'agentRoleScript',
+    subSteps: [
+      { key: 'analyze_novel', titleKey: 'subStepAnalyzeNovel', titleFallback: '分析小说文本' },
+      { key: 'extract_characters', titleKey: 'subStepExtractCharacters', titleFallback: '提取角色与场景' },
+      { key: 'generate_scripts', titleKey: 'subStepGenerateScripts', titleFallback: '生成分集剧本' },
+    ],
   },
   {
     stepKey: 'art_director_agent',
@@ -35,6 +51,11 @@ export const AGENT_IDENTITIES: AgentIdentity[] = [
     accentColor: 'text-amber-400',
     nameKey: 'agentArt',
     roleKey: 'agentRoleArt',
+    subSteps: [
+      { key: 'create_style_profile', titleKey: 'subStepCreateStyleProfile', titleFallback: '创建风格档案' },
+      { key: 'generate_characters', titleKey: 'subStepGenerateCharacters', titleFallback: '生成角色立绘' },
+      { key: 'generate_locations', titleKey: 'subStepGenerateLocations', titleFallback: '生成场景图' },
+    ],
   },
   {
     stepKey: 'storyboard_agent',
@@ -44,6 +65,10 @@ export const AGENT_IDENTITIES: AgentIdentity[] = [
     accentColor: 'text-cyan-400',
     nameKey: 'agentStoryboard',
     roleKey: 'agentRoleStoryboard',
+    subSteps: [
+      { key: 'generate_storyboard_scripts', titleKey: 'subStepGenerateStoryboardScripts', titleFallback: '生成分镜脚本' },
+      { key: 'batch_generate_panels', titleKey: 'subStepBatchGeneratePanels', titleFallback: '批量生成分镜图' },
+    ],
   },
   {
     stepKey: 'producer_quality_check',
@@ -53,6 +78,11 @@ export const AGENT_IDENTITIES: AgentIdentity[] = [
     accentColor: 'text-emerald-400',
     nameKey: 'agentProducer',
     roleKey: 'agentRoleProducer',
+    subSteps: [
+      { key: 'create_review_items', titleKey: 'subStepCreateReviewItems', titleFallback: '创建审核项' },
+      { key: 'quality_scoring', titleKey: 'subStepQualityScoring', titleFallback: '质量评分' },
+      { key: 'generate_report', titleKey: 'subStepGenerateReport', titleFallback: '生成审核报告' },
+    ],
   },
   {
     stepKey: 'video_generation_agent',
@@ -62,6 +92,7 @@ export const AGENT_IDENTITIES: AgentIdentity[] = [
     accentColor: 'text-rose-400',
     nameKey: 'agentVideo',
     roleKey: 'agentRoleVideo',
+    subSteps: [],
   },
   {
     stepKey: 'voice_generation_agent',
@@ -71,6 +102,7 @@ export const AGENT_IDENTITIES: AgentIdentity[] = [
     accentColor: 'text-sky-400',
     nameKey: 'agentVoice',
     roleKey: 'agentRoleVoice',
+    subSteps: [],
   },
   {
     stepKey: 'assembly_agent',
@@ -80,6 +112,7 @@ export const AGENT_IDENTITIES: AgentIdentity[] = [
     accentColor: 'text-yellow-400',
     nameKey: 'agentAssembly',
     roleKey: 'agentRoleAssembly',
+    subSteps: [],
   },
 ]
 

--- a/src/lib/agent-pipeline/graph/nodes/art-director.ts
+++ b/src/lib/agent-pipeline/graph/nodes/art-director.ts
@@ -26,6 +26,7 @@ export async function runArtDirectorAgent(
 
   logger.info({ action: 'art_director.start', message: 'Starting art direction' })
   await log('开始美术资产生成')
+  await context.emitSubStep('create_style_profile', 'running')
 
   const novelData = await prisma.novelPromotionProject.findUnique({
     where: { projectId: state.projectId },
@@ -43,6 +44,8 @@ export async function runArtDirectorAgent(
   })
   state.styleProfile = styleProfile
   await log(`风格配置: ${novelData.artStyle || 'default'}`)
+  await context.emitSubStep('create_style_profile', 'completed')
+  await context.emitSubStep('generate_characters', 'running')
 
   // Step 2a: Ensure character appearances exist (generate visual profiles)
   const unconfirmedChars = await prisma.novelPromotionCharacter.findMany({
@@ -94,6 +97,8 @@ export async function runArtDirectorAgent(
   if (charsToGenerate.length > 0) {
     await log(`${charsToGenerate.length} 个角色图片生成完成`)
   }
+  await context.emitSubStep('generate_characters', 'completed')
+  await context.emitSubStep('generate_locations', 'running')
 
   // Step 3: Generate location images
   const locations = await getLocationAssets(novelData.id)
@@ -121,6 +126,7 @@ export async function runArtDirectorAgent(
   if (locsToGenerate.length > 0) {
     await log(`${locsToGenerate.length} 个场景图片生成完成`)
   }
+  await context.emitSubStep('generate_locations', 'completed')
 
   // Step 4: Lock all assets
   const updatedCharacters = await getCharacterAssets(novelData.id)

--- a/src/lib/agent-pipeline/graph/nodes/producer.ts
+++ b/src/lib/agent-pipeline/graph/nodes/producer.ts
@@ -24,6 +24,7 @@ export async function runProducerQualityCheck(
 
   logger.info({ action: 'producer.quality_check', message: 'Running final quality check' })
   await log('开始质量检查与审核项创建')
+  await context.emitSubStep('create_review_items', 'running')
 
   const novelData = await prisma.novelPromotionProject.findUnique({
     where: { projectId: state.projectId },
@@ -87,6 +88,8 @@ export async function runProducerQualityCheck(
     })),
   )
   await log(`创建 ${panels.length} 个分镜画面审核项`)
+  await context.emitSubStep('create_review_items', 'completed')
+  await context.emitSubStep('quality_scoring', 'running')
 
   // Check if all items are already auto-passed — if so, go directly to completed
   const pendingCount = await prisma.pipelineReviewItem.count({
@@ -116,8 +119,11 @@ export async function runProducerQualityCheck(
     state.currentPhase = 'video'
     await log(`${pendingCount} 项待审核，继续视频/配音/成片流程`)
   }
+  await context.emitSubStep('quality_scoring', 'completed')
+  await context.emitSubStep('generate_report', 'running')
 
   await log(`质量检查完成，共创建 ${characters.length + locations.length + panels.length} 个审核项`)
+  await context.emitSubStep('generate_report', 'completed')
   logger.info({
     action: 'producer.quality_check.complete',
     message: `Created review items: ${characters.length} characters, ${locations.length} locations, ${panels.length} panels`,

--- a/src/lib/agent-pipeline/graph/nodes/script-agent.ts
+++ b/src/lib/agent-pipeline/graph/nodes/script-agent.ts
@@ -25,6 +25,7 @@ export async function runScriptAgent(
 
   logger.info({ action: 'script_agent.start', message: 'Starting script analysis' })
   await log('开始剧本分析')
+  await context.emitSubStep('analyze_novel', 'running')
 
   // Step 1: Get novel project
   const novelData = await prisma.novelPromotionProject.findUnique({
@@ -49,6 +50,8 @@ export async function runScriptAgent(
   })
   await waitForTaskCompletion(analyzeResult.taskId, state.projectId)
   await log('小说分析完成')
+  await context.emitSubStep('analyze_novel', 'completed')
+  await context.emitSubStep('extract_characters', 'running')
 
   // Step 3: Read extracted characters and locations from DB
   const characters = await prisma.novelPromotionCharacter.findMany({
@@ -73,6 +76,8 @@ export async function runScriptAgent(
       await updatePromptFragment('location', loc.id, loc.summary)
     }
   }
+  await context.emitSubStep('extract_characters', 'completed')
+  await context.emitSubStep('generate_scripts', 'running')
 
   // Step 5: Submit story_to_script_run task for each episode
   const episodes = await prisma.novelPromotionEpisode.findMany({
@@ -100,6 +105,7 @@ export async function runScriptAgent(
   }
 
   await log(`剧本生成完成，共 ${episodes.length} 集`)
+  await context.emitSubStep('generate_scripts', 'completed')
 
   // Update state
   state.characters = characters.map((c) => ({

--- a/src/lib/agent-pipeline/graph/nodes/storyboard-agent.ts
+++ b/src/lib/agent-pipeline/graph/nodes/storyboard-agent.ts
@@ -24,6 +24,7 @@ export async function runStoryboardAgent(
 
   logger.info({ action: 'storyboard_agent.start', message: 'Starting storyboard generation' })
   await log('开始分镜生成')
+  await context.emitSubStep('generate_storyboard_scripts', 'running')
 
   // Step 1: Run script-to-storyboard for each episode
   for (let i = 0; i < state.episodeIds.length; i++) {
@@ -43,6 +44,8 @@ export async function runStoryboardAgent(
     })
     await waitForTaskCompletion(storyboardResult.taskId, state.projectId)
   }
+  await context.emitSubStep('generate_storyboard_scripts', 'completed')
+  await context.emitSubStep('batch_generate_panels', 'running')
 
   // Step 2: Batch generate panel images
   const novelData = await prisma.novelPromotionProject.findUnique({
@@ -90,6 +93,7 @@ export async function runStoryboardAgent(
   state.currentPhase = 'review'
 
   await log(`分镜生成完成，共 ${panels.length} 个画面`)
+  await context.emitSubStep('batch_generate_panels', 'completed')
   logger.info({
     action: 'storyboard_agent.complete',
     message: `Generated storyboards and ${panels.length} panel images`,

--- a/src/lib/agent-pipeline/graph/super-graph.ts
+++ b/src/lib/agent-pipeline/graph/super-graph.ts
@@ -10,6 +10,7 @@ import { runVideoGenerationAgent } from './nodes/video-generator'
 import { runVoiceGenerationAgent } from './nodes/voice-generator'
 import { runAssemblyAgent } from './nodes/assembly-agent'
 import type { PipelineConfig } from '../types'
+import type { ResumeContext } from '../pipeline-types'
 
 export type StartPipelineInput = {
   runId: string
@@ -20,76 +21,98 @@ export type StartPipelineInput = {
   artStyle: string
   aspectRatio: string
   config: PipelineConfig
+  resumeFrom?: ResumeContext
 }
 
 export async function runAgentPipelineGraph(
   input: StartPipelineInput,
 ): Promise<PipelineState> {
-  const initialState = createInitialPipelineState({
-    projectId: input.projectId,
-    userId: input.userId,
-    pipelineRunId: input.pipelineRunId,
-    script: input.script,
-    artStyle: input.artStyle,
-    aspectRatio: input.aspectRatio,
-    config: input.config,
-  })
+  const allNodes = [
+    {
+      key: 'script_agent',
+      title: 'Script Analysis & Story-to-Script',
+      maxAttempts: 2,
+      timeoutMs: 30 * 60 * 1000,
+      run: runScriptAgent,
+    },
+    {
+      key: 'art_director_agent',
+      title: 'Character & Location Image Generation',
+      maxAttempts: 2,
+      timeoutMs: 30 * 60 * 1000,
+      run: runArtDirectorAgent,
+    },
+    {
+      key: 'storyboard_agent',
+      title: 'Storyboard & Panel Image Generation',
+      maxAttempts: 2,
+      timeoutMs: 60 * 60 * 1000,
+      run: runStoryboardAgent,
+    },
+    {
+      key: 'producer_quality_check',
+      title: 'Quality Check & Review Items',
+      maxAttempts: 1,
+      timeoutMs: 5 * 60 * 1000,
+      run: runProducerQualityCheck,
+    },
+    {
+      key: 'video_generation_agent',
+      title: 'Video Generation for Panels',
+      maxAttempts: 2,
+      timeoutMs: 60 * 60 * 1000,
+      run: runVideoGenerationAgent,
+    },
+    {
+      key: 'voice_generation_agent',
+      title: 'Voice Analysis & Audio Generation',
+      maxAttempts: 2,
+      timeoutMs: 30 * 60 * 1000,
+      run: runVoiceGenerationAgent,
+    },
+    {
+      key: 'assembly_agent',
+      title: 'Auto Assembly & Final Composition',
+      maxAttempts: 2,
+      timeoutMs: 30 * 60 * 1000,
+      run: runAssemblyAgent,
+    },
+  ]
+
+  let initialState: PipelineState
+  let nodes = allNodes
+
+  if (input.resumeFrom) {
+    // Restore state from checkpoint
+    initialState = input.resumeFrom.checkpointState as PipelineState
+    // Ensure refs and meta exist (checkpoint might have lean state)
+    initialState.refs = initialState.refs || {}
+    initialState.meta = initialState.meta || {}
+
+    // Filter out completed nodes
+    const completedSet = new Set(input.resumeFrom.completedNodes)
+    nodes = allNodes.filter((n) => !completedSet.has(n.key))
+  } else {
+    initialState = createInitialPipelineState({
+      projectId: input.projectId,
+      userId: input.userId,
+      pipelineRunId: input.pipelineRunId,
+      script: input.script,
+      artStyle: input.artStyle,
+      aspectRatio: input.aspectRatio,
+      config: input.config,
+    })
+  }
+
+  if (nodes.length === 0) {
+    return initialState
+  }
 
   return await runPipelineGraph({
     runId: input.runId,
     projectId: input.projectId,
     userId: input.userId,
     state: initialState,
-    nodes: [
-      {
-        key: 'script_agent',
-        title: 'Script Analysis & Story-to-Script',
-        maxAttempts: 2,
-        timeoutMs: 30 * 60 * 1000, // 30 minutes
-        run: runScriptAgent,
-      },
-      {
-        key: 'art_director_agent',
-        title: 'Character & Location Image Generation',
-        maxAttempts: 2,
-        timeoutMs: 30 * 60 * 1000,
-        run: runArtDirectorAgent,
-      },
-      {
-        key: 'storyboard_agent',
-        title: 'Storyboard & Panel Image Generation',
-        maxAttempts: 2,
-        timeoutMs: 60 * 60 * 1000, // 60 minutes (many panels)
-        run: runStoryboardAgent,
-      },
-      {
-        key: 'producer_quality_check',
-        title: 'Quality Check & Review Items',
-        maxAttempts: 1,
-        timeoutMs: 5 * 60 * 1000,
-        run: runProducerQualityCheck,
-      },
-      {
-        key: 'video_generation_agent',
-        title: 'Video Generation for Panels',
-        maxAttempts: 2,
-        timeoutMs: 60 * 60 * 1000, // 60 minutes (many video generations)
-        run: runVideoGenerationAgent,
-      },
-      {
-        key: 'voice_generation_agent',
-        title: 'Voice Analysis & Audio Generation',
-        maxAttempts: 2,
-        timeoutMs: 30 * 60 * 1000,
-        run: runVoiceGenerationAgent,
-      },
-      {
-        key: 'assembly_agent',
-        title: 'Auto Assembly & Final Composition',
-        maxAttempts: 2,
-        timeoutMs: 30 * 60 * 1000,
-        run: runAssemblyAgent,
-      },
-    ],
+    nodes,
   })
 }

--- a/src/lib/agent-pipeline/index.ts
+++ b/src/lib/agent-pipeline/index.ts
@@ -136,3 +136,179 @@ export async function startPipeline(params: {
 
   return { pipelineRunId: pipelineRun.id, runId: graphRun.id }
 }
+
+export async function resumePipeline(params: {
+  userId: string
+  projectId: string
+  pipelineRunId: string
+}): Promise<{ resumed: boolean }> {
+  const logger = createScopedLogger({
+    module: 'agent-pipeline',
+    projectId: params.projectId,
+    userId: params.userId,
+  })
+
+  const pipelineRun = await prisma.pipelineRun.findUnique({
+    where: { id: params.pipelineRunId },
+  })
+  if (!pipelineRun || pipelineRun.status !== PIPELINE_STATUS.PAUSED) {
+    throw new Error('Pipeline is not paused')
+  }
+
+  // Find the GraphRun
+  const graphRun = await prisma.graphRun.findFirst({
+    where: {
+      targetType: 'PipelineRun',
+      targetId: params.pipelineRunId,
+    },
+  })
+  if (!graphRun) {
+    throw new Error('GraphRun not found for pipeline')
+  }
+
+  // Get completed step keys
+  const completedSteps = await prisma.graphStep.findMany({
+    where: {
+      runId: graphRun.id,
+      status: 'completed',
+    },
+    select: { stepKey: true },
+    orderBy: { stepIndex: 'asc' },
+  })
+  const completedNodes = completedSteps.map((s) => s.stepKey)
+
+  // Get latest checkpoint state
+  const checkpoints = await prisma.graphCheckpoint.findMany({
+    where: { runId: graphRun.id },
+    orderBy: { createdAt: 'desc' },
+    take: 1,
+  })
+
+  // Build checkpoint state
+  let checkpointState: Record<string, unknown> = {}
+  if (checkpoints.length > 0 && checkpoints[0].stateJson) {
+    const saved = checkpoints[0].stateJson as Record<string, unknown>
+    const novelData = await prisma.novelPromotionProject.findUnique({
+      where: { projectId: params.projectId },
+      select: { artStyle: true, videoRatio: true },
+    })
+
+    const config = (pipelineRun.config as PipelineConfig) || DEFAULT_PIPELINE_CONFIG
+
+    checkpointState = {
+      refs: saved.refs || {},
+      meta: saved.meta || {},
+      projectId: params.projectId,
+      userId: params.userId,
+      pipelineRunId: params.pipelineRunId,
+      script: '',
+      artStyle: novelData?.artStyle || '',
+      aspectRatio: novelData?.videoRatio || '9:16',
+      config,
+      characters: [],
+      locations: [],
+      episodeIds: [],
+      styleProfile: null,
+      characterAssetsLocked: completedNodes.includes('art_director_agent'),
+      locationAssetsLocked: completedNodes.includes('art_director_agent'),
+      storyboardComplete: completedNodes.includes('storyboard_agent'),
+      panelCount: 0,
+      currentPhase: pipelineRun.currentPhase || 'script',
+      qualityGates: [],
+      error: null,
+    }
+  }
+
+  // Update statuses
+  await prisma.pipelineRun.update({
+    where: { id: params.pipelineRunId },
+    data: { status: PIPELINE_STATUS.RUNNING },
+  })
+  await prisma.graphRun.updateMany({
+    where: { id: graphRun.id },
+    data: { status: 'running' },
+  })
+
+  // Reset any failed/running steps that will be re-run
+  await prisma.graphStep.updateMany({
+    where: {
+      runId: graphRun.id,
+      status: { in: ['running', 'failed'] },
+    },
+    data: {
+      status: 'pending',
+      finishedAt: null,
+      lastErrorCode: null,
+      lastErrorMessage: null,
+    },
+  })
+
+  const novelData = await prisma.novelPromotionProject.findUnique({
+    where: { projectId: params.projectId },
+    select: { artStyle: true, videoRatio: true },
+  })
+
+  logger.info({
+    action: 'pipeline.resume',
+    message: `Resuming pipeline from after: ${completedNodes.join(', ') || 'beginning'}`,
+  })
+
+  // Run pipeline in background with resume context
+  runAgentPipelineGraph({
+    runId: graphRun.id,
+    projectId: params.projectId,
+    userId: params.userId,
+    pipelineRunId: params.pipelineRunId,
+    script: '',
+    artStyle: novelData?.artStyle || '',
+    aspectRatio: novelData?.videoRatio || '9:16',
+    config: (pipelineRun.config as PipelineConfig) || DEFAULT_PIPELINE_CONFIG,
+    resumeFrom: {
+      completedNodes,
+      checkpointState,
+    },
+  })
+    .then(async () => {
+      const current = await prisma.pipelineRun.findUnique({
+        where: { id: params.pipelineRunId },
+        select: { status: true },
+      })
+      if (current && current.status === PIPELINE_STATUS.RUNNING) {
+        await prisma.pipelineRun.update({
+          where: { id: params.pipelineRunId },
+          data: {
+            status: PIPELINE_STATUS.REVIEW,
+            completedAt: new Date(),
+          },
+        })
+      }
+    })
+    .catch(async (error: unknown) => {
+      if (error instanceof PipelinePausedError) {
+        await prisma.graphRun.updateMany({
+          where: { id: graphRun.id, status: { in: ['running', 'queued'] } },
+          data: { status: 'paused' },
+        })
+        logger.info({ action: 'pipeline.paused', message: 'Pipeline paused again' })
+        return
+      }
+
+      const message = error instanceof Error ? error.message : String(error)
+      await prisma.pipelineRun.update({
+        where: { id: params.pipelineRunId },
+        data: {
+          status: PIPELINE_STATUS.FAILED,
+          errorMessage: message,
+          completedAt: new Date(),
+        },
+      })
+      logger.error({
+        action: 'pipeline.failed',
+        message,
+        errorCode: 'PIPELINE_FAILED',
+        retryable: false,
+      })
+    })
+
+  return { resumed: true }
+}

--- a/src/lib/agent-pipeline/index.ts
+++ b/src/lib/agent-pipeline/index.ts
@@ -5,6 +5,7 @@ import { createRun } from '@/lib/run-runtime/service'
 import { getProjectModelConfig, checkRequiredModels } from '@/lib/config-service'
 import { DEFAULT_PIPELINE_CONFIG, PIPELINE_STATUS, type PipelineConfig } from './types'
 import { runAgentPipelineGraph } from './graph/super-graph'
+import { PipelinePausedError } from '@/lib/run-runtime/graph-executor'
 import { createScopedLogger } from '@/lib/logging/core'
 
 export async function startPipeline(params: {
@@ -103,6 +104,19 @@ export async function startPipeline(params: {
       }
     })
     .catch(async (error: unknown) => {
+      if (error instanceof PipelinePausedError) {
+        // Pipeline was paused — update GraphRun status and leave PipelineRun as paused
+        await prisma.graphRun.updateMany({
+          where: { id: graphRun.id, status: { in: ['running', 'queued'] } },
+          data: { status: 'paused' },
+        })
+        logger.info({
+          action: 'pipeline.paused',
+          message: 'Pipeline paused by user',
+        })
+        return
+      }
+
       const message = error instanceof Error ? error.message : String(error)
       await prisma.pipelineRun.update({
         where: { id: pipelineRun.id },

--- a/src/lib/agent-pipeline/index.ts
+++ b/src/lib/agent-pipeline/index.ts
@@ -177,6 +177,11 @@ export async function resumePipeline(params: {
   })
   const completedNodes = completedSteps.map((s) => s.stepKey)
 
+  const novelData = await prisma.novelPromotionProject.findUnique({
+    where: { projectId: params.projectId },
+    select: { artStyle: true, videoRatio: true },
+  })
+
   // Get latest checkpoint state
   const checkpoints = await prisma.graphCheckpoint.findMany({
     where: { runId: graphRun.id },
@@ -184,39 +189,34 @@ export async function resumePipeline(params: {
     take: 1,
   })
 
+  if (checkpoints.length === 0) {
+    throw new Error('No checkpoint found for paused pipeline — cannot resume')
+  }
+
   // Build checkpoint state
-  let checkpointState: Record<string, unknown> = {}
-  if (checkpoints.length > 0 && checkpoints[0].stateJson) {
-    const saved = checkpoints[0].stateJson as Record<string, unknown>
-    const novelData = await prisma.novelPromotionProject.findUnique({
-      where: { projectId: params.projectId },
-      select: { artStyle: true, videoRatio: true },
-    })
-
-    const config = (pipelineRun.config as PipelineConfig) || DEFAULT_PIPELINE_CONFIG
-
-    checkpointState = {
-      refs: saved.refs || {},
-      meta: saved.meta || {},
-      projectId: params.projectId,
-      userId: params.userId,
-      pipelineRunId: params.pipelineRunId,
-      script: '',
-      artStyle: novelData?.artStyle || '',
-      aspectRatio: novelData?.videoRatio || '9:16',
-      config,
-      characters: [],
-      locations: [],
-      episodeIds: [],
-      styleProfile: null,
-      characterAssetsLocked: completedNodes.includes('art_director_agent'),
-      locationAssetsLocked: completedNodes.includes('art_director_agent'),
-      storyboardComplete: completedNodes.includes('storyboard_agent'),
-      panelCount: 0,
-      currentPhase: pipelineRun.currentPhase || 'script',
-      qualityGates: [],
-      error: null,
-    }
+  const saved = (checkpoints[0].stateJson || {}) as Record<string, unknown>
+  const config = (pipelineRun.config as PipelineConfig) || DEFAULT_PIPELINE_CONFIG
+  const checkpointState: Record<string, unknown> = {
+    refs: saved.refs || {},
+    meta: saved.meta || {},
+    projectId: params.projectId,
+    userId: params.userId,
+    pipelineRunId: params.pipelineRunId,
+    script: '',
+    artStyle: novelData?.artStyle || '',
+    aspectRatio: novelData?.videoRatio || '9:16',
+    config,
+    characters: [],
+    locations: [],
+    episodeIds: [],
+    styleProfile: null,
+    characterAssetsLocked: completedNodes.includes('art_director_agent'),
+    locationAssetsLocked: completedNodes.includes('art_director_agent'),
+    storyboardComplete: completedNodes.includes('storyboard_agent'),
+    panelCount: 0,
+    currentPhase: pipelineRun.currentPhase || 'script',
+    qualityGates: [],
+    error: null,
   }
 
   // Update statuses
@@ -241,11 +241,6 @@ export async function resumePipeline(params: {
       lastErrorCode: null,
       lastErrorMessage: null,
     },
-  })
-
-  const novelData = await prisma.novelPromotionProject.findUnique({
-    where: { projectId: params.projectId },
-    select: { artStyle: true, videoRatio: true },
   })
 
   logger.info({
@@ -277,7 +272,7 @@ export async function resumePipeline(params: {
         await prisma.pipelineRun.update({
           where: { id: params.pipelineRunId },
           data: {
-            status: PIPELINE_STATUS.REVIEW,
+            status: PIPELINE_STATUS.COMPLETED,
             completedAt: new Date(),
           },
         })

--- a/src/lib/agent-pipeline/pipeline-status-service.ts
+++ b/src/lib/agent-pipeline/pipeline-status-service.ts
@@ -176,28 +176,45 @@ export async function getPipelineRunDetail(projectId: string): Promise<PipelineS
     })
   } else {
     // No GraphStep records — build fallback steps from agent identities
-    // and infer status from sub-step events and pipeline phase progression
-    const pipelinePhase = pipelineRun.currentPhase
-    const phaseOrder = AGENT_IDENTITIES.map((a) => a.phaseKey)
-    const currentPhaseIdx = pipelinePhase ? phaseOrder.indexOf(pipelinePhase) : -1
+    // and infer status from sub-step events
+    const pipelineFailed = pipelineRun.status === 'failed'
 
     steps = AGENT_IDENTITIES.map((agent, index) => {
       const stepSubEvents = subStepEvents.filter((e) => e.stepKey === agent.stepKey)
       const hasEvents = stepSubEvents.length > 0
 
+      // Count completed sub-steps from events
+      const completedKeys = new Set<string>()
+      const startedKeys = new Set<string>()
+      const failedKeys = new Set<string>()
+      for (const e of stepSubEvents) {
+        const key = (e.payload as Record<string, unknown> | null)?.subStepKey as string | undefined
+        if (!key) continue
+        if (e.eventType === 'substep.complete') completedKeys.add(key)
+        else if (e.eventType === 'substep.start') startedKeys.add(key)
+        else if (e.eventType === 'substep.error') failedKeys.add(key)
+      }
+
+      const identity = getAgentByStepKey(agent.stepKey)
+      const totalSubSteps = identity?.subSteps.length ?? 0
+      const allSubStepsDone = totalSubSteps > 0 && completedKeys.size >= totalSubSteps
+
       let stepStatus: string
-      if (index < currentPhaseIdx) {
+      if (allSubStepsDone) {
         stepStatus = 'completed'
-      } else if (index === currentPhaseIdx) {
-        stepStatus = pipelineRun.status === 'failed' ? 'failed' : 'running'
+      } else if (failedKeys.size > 0) {
+        stepStatus = 'failed'
+      } else if (hasEvents && pipelineFailed) {
+        // Had some events but not all completed, and pipeline failed
+        stepStatus = 'failed'
       } else if (hasEvents) {
-        // Has sub-step events — check if all completed
-        const allComplete = stepSubEvents.every((e) => e.eventType === 'substep.complete' || e.eventType === 'substep.start')
-        const hasComplete = stepSubEvents.some((e) => e.eventType === 'substep.complete')
-        stepStatus = hasComplete && allComplete ? 'completed' : 'running'
+        stepStatus = 'running'
       } else {
         stepStatus = 'pending'
       }
+
+      // Only attach error message to the step that actually failed
+      const isFailedStep = stepStatus === 'failed'
 
       return {
         stepKey: agent.stepKey,
@@ -206,7 +223,7 @@ export async function getPipelineRunDetail(projectId: string): Promise<PipelineS
         stepIndex: index,
         startedAt: null,
         finishedAt: null,
-        lastErrorMessage: index === currentPhaseIdx && pipelineRun.status === 'failed' ? pipelineRun.errorMessage : null,
+        lastErrorMessage: isFailedStep ? pipelineRun.errorMessage : null,
         usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
         subSteps: buildSubSteps(agent.stepKey, stepSubEvents, stepStatus),
       }

--- a/src/lib/agent-pipeline/pipeline-status-service.ts
+++ b/src/lib/agent-pipeline/pipeline-status-service.ts
@@ -3,7 +3,7 @@
 import { prisma } from '@/lib/prisma'
 import { getReviewSummary } from './review/review-service'
 import type { ReviewSummary } from './review/types'
-import { getAgentByStepKey } from './agent-identities'
+import { getAgentByStepKey, AGENT_IDENTITIES } from './agent-identities'
 import type { TokenUsage, StepInfo, SubStepInfo, ActiveTaskInfo, PipelineLogEntry } from './pipeline-types'
 
 export type PipelineStatusDetail = {
@@ -145,32 +145,73 @@ export async function getPipelineRunDetail(projectId: string): Promise<PipelineS
   ])
 
   const totalUsage: TokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
-  const steps: StepInfo[] = graphSteps.map((s) => {
-    const stepUsage: TokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
-    for (const attempt of s.attempts) {
-      const au = sumUsageFromJson(attempt.usageJson)
-      stepUsage.promptTokens += au.promptTokens
-      stepUsage.completionTokens += au.completionTokens
-      stepUsage.totalTokens += au.totalTokens
-    }
-    totalUsage.promptTokens += stepUsage.promptTokens
-    totalUsage.completionTokens += stepUsage.completionTokens
-    totalUsage.totalTokens += stepUsage.totalTokens
+  let steps: StepInfo[]
 
-    const stepSubEvents = subStepEvents.filter((e) => e.stepKey === s.stepKey)
+  if (graphSteps.length > 0) {
+    steps = graphSteps.map((s) => {
+      const stepUsage: TokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
+      for (const attempt of s.attempts) {
+        const au = sumUsageFromJson(attempt.usageJson)
+        stepUsage.promptTokens += au.promptTokens
+        stepUsage.completionTokens += au.completionTokens
+        stepUsage.totalTokens += au.totalTokens
+      }
+      totalUsage.promptTokens += stepUsage.promptTokens
+      totalUsage.completionTokens += stepUsage.completionTokens
+      totalUsage.totalTokens += stepUsage.totalTokens
 
-    return {
-      stepKey: s.stepKey,
-      stepTitle: s.stepTitle,
-      status: s.status,
-      stepIndex: s.stepIndex,
-      startedAt: s.startedAt?.toISOString() ?? null,
-      finishedAt: s.finishedAt?.toISOString() ?? null,
-      lastErrorMessage: s.lastErrorMessage,
-      usage: stepUsage,
-      subSteps: buildSubSteps(s.stepKey, stepSubEvents, s.status),
-    }
-  })
+      const stepSubEvents = subStepEvents.filter((e) => e.stepKey === s.stepKey)
+
+      return {
+        stepKey: s.stepKey,
+        stepTitle: s.stepTitle,
+        status: s.status,
+        stepIndex: s.stepIndex,
+        startedAt: s.startedAt?.toISOString() ?? null,
+        finishedAt: s.finishedAt?.toISOString() ?? null,
+        lastErrorMessage: s.lastErrorMessage,
+        usage: stepUsage,
+        subSteps: buildSubSteps(s.stepKey, stepSubEvents, s.status),
+      }
+    })
+  } else {
+    // No GraphStep records — build fallback steps from agent identities
+    // and infer status from sub-step events and pipeline phase progression
+    const pipelinePhase = pipelineRun.currentPhase
+    const phaseOrder = AGENT_IDENTITIES.map((a) => a.phaseKey)
+    const currentPhaseIdx = pipelinePhase ? phaseOrder.indexOf(pipelinePhase) : -1
+
+    steps = AGENT_IDENTITIES.map((agent, index) => {
+      const stepSubEvents = subStepEvents.filter((e) => e.stepKey === agent.stepKey)
+      const hasEvents = stepSubEvents.length > 0
+
+      let stepStatus: string
+      if (index < currentPhaseIdx) {
+        stepStatus = 'completed'
+      } else if (index === currentPhaseIdx) {
+        stepStatus = pipelineRun.status === 'failed' ? 'failed' : 'running'
+      } else if (hasEvents) {
+        // Has sub-step events — check if all completed
+        const allComplete = stepSubEvents.every((e) => e.eventType === 'substep.complete' || e.eventType === 'substep.start')
+        const hasComplete = stepSubEvents.some((e) => e.eventType === 'substep.complete')
+        stepStatus = hasComplete && allComplete ? 'completed' : 'running'
+      } else {
+        stepStatus = 'pending'
+      }
+
+      return {
+        stepKey: agent.stepKey,
+        stepTitle: '',
+        status: stepStatus,
+        stepIndex: index,
+        startedAt: null,
+        finishedAt: null,
+        lastErrorMessage: index === currentPhaseIdx && pipelineRun.status === 'failed' ? pipelineRun.errorMessage : null,
+        usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        subSteps: buildSubSteps(agent.stepKey, stepSubEvents, stepStatus),
+      }
+    })
+  }
 
   let activeTask: ActiveTaskInfo | null = null
   if (activeTasks.length > 0) {

--- a/src/lib/agent-pipeline/pipeline-status-service.ts
+++ b/src/lib/agent-pipeline/pipeline-status-service.ts
@@ -39,6 +39,7 @@ function sumUsageFromJson(usageJson: unknown): TokenUsage {
 function buildSubSteps(
   stepKey: string,
   events: Array<{ eventType: string; payload: unknown; createdAt: Date }>,
+  parentStepStatus: string,
 ): SubStepInfo[] {
   const identity = getAgentByStepKey(stepKey)
   if (!identity) return []
@@ -66,12 +67,18 @@ function buildSubSteps(
     subStepStates.set(subStepKey, existing)
   }
 
+  // When the parent step completed but no sub-step events exist (e.g. due to
+  // the earlier seq=0 bug), infer all sub-steps as completed.
+  const hasNoEvents = subStepStates.size === 0
+  const parentDone = parentStepStatus === 'completed' || parentStepStatus === 'failed'
+
   return identity.subSteps.map((def) => {
     const state = subStepStates.get(def.key)
+    const fallbackStatus: SubStepInfo['status'] = hasNoEvents && parentDone ? 'completed' : 'pending'
     return {
       key: def.key,
       title: def.titleFallback,
-      status: state?.status ?? 'pending',
+      status: state?.status ?? fallbackStatus,
       startedAt: state?.startedAt?.toISOString() ?? null,
       completedAt: state?.completedAt?.toISOString() ?? null,
     }
@@ -161,7 +168,7 @@ export async function getPipelineRunDetail(projectId: string): Promise<PipelineS
       finishedAt: s.finishedAt?.toISOString() ?? null,
       lastErrorMessage: s.lastErrorMessage,
       usage: stepUsage,
-      subSteps: buildSubSteps(s.stepKey, stepSubEvents),
+      subSteps: buildSubSteps(s.stepKey, stepSubEvents, s.status),
     }
   })
 

--- a/src/lib/agent-pipeline/pipeline-status-service.ts
+++ b/src/lib/agent-pipeline/pipeline-status-service.ts
@@ -3,7 +3,8 @@
 import { prisma } from '@/lib/prisma'
 import { getReviewSummary } from './review/review-service'
 import type { ReviewSummary } from './review/types'
-import type { TokenUsage, StepInfo, ActiveTaskInfo, PipelineLogEntry } from './pipeline-types'
+import { getAgentByStepKey } from './agent-identities'
+import type { TokenUsage, StepInfo, SubStepInfo, ActiveTaskInfo, PipelineLogEntry } from './pipeline-types'
 
 export type PipelineStatusDetail = {
   exists: true
@@ -35,6 +36,48 @@ function sumUsageFromJson(usageJson: unknown): TokenUsage {
   return { promptTokens: prompt, completionTokens: completion, totalTokens: prompt + completion }
 }
 
+function buildSubSteps(
+  stepKey: string,
+  events: Array<{ eventType: string; payload: unknown; createdAt: Date }>,
+): SubStepInfo[] {
+  const identity = getAgentByStepKey(stepKey)
+  if (!identity) return []
+
+  const subStepStates = new Map<string, { status: SubStepInfo['status']; startedAt: Date | null; completedAt: Date | null }>()
+
+  for (const event of events) {
+    const payload = event.payload as Record<string, unknown> | null
+    const subStepKey = payload?.subStepKey as string | undefined
+    if (!subStepKey) continue
+
+    const existing = subStepStates.get(subStepKey) || { status: 'pending' as const, startedAt: null, completedAt: null }
+
+    if (event.eventType === 'substep.start') {
+      existing.status = 'running'
+      existing.startedAt = event.createdAt
+    } else if (event.eventType === 'substep.complete') {
+      existing.status = 'completed'
+      existing.completedAt = event.createdAt
+    } else if (event.eventType === 'substep.error') {
+      existing.status = 'failed'
+      existing.completedAt = event.createdAt
+    }
+
+    subStepStates.set(subStepKey, existing)
+  }
+
+  return identity.subSteps.map((def) => {
+    const state = subStepStates.get(def.key)
+    return {
+      key: def.key,
+      title: def.titleFallback,
+      status: state?.status ?? 'pending',
+      startedAt: state?.startedAt?.toISOString() ?? null,
+      completedAt: state?.completedAt?.toISOString() ?? null,
+    }
+  })
+}
+
 export async function getPipelineRunDetail(projectId: string): Promise<PipelineStatusResponse> {
   const pipelineRun = await prisma.pipelineRun.findFirst({
     where: { projectId },
@@ -55,7 +98,7 @@ export async function getPipelineRunDetail(projectId: string): Promise<PipelineS
   })
 
   // Parallelize independent queries
-  const [graphSteps, activeTasks, reviewSummary] = await Promise.all([
+  const [graphSteps, activeTasks, reviewSummary, subStepEvents] = await Promise.all([
     graphRun
       ? prisma.graphStep.findMany({
           where: { runId: graphRun.id },
@@ -83,6 +126,15 @@ export async function getPipelineRunDetail(projectId: string): Promise<PipelineS
       },
     }),
     getReviewSummary(pipelineRun.id),
+    graphRun
+      ? prisma.graphEvent.findMany({
+          where: {
+            runId: graphRun.id,
+            eventType: { startsWith: 'substep.' },
+          },
+          orderBy: { createdAt: 'asc' },
+        })
+      : Promise.resolve([]),
   ])
 
   const totalUsage: TokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
@@ -98,6 +150,8 @@ export async function getPipelineRunDetail(projectId: string): Promise<PipelineS
     totalUsage.completionTokens += stepUsage.completionTokens
     totalUsage.totalTokens += stepUsage.totalTokens
 
+    const stepSubEvents = subStepEvents.filter((e) => e.stepKey === s.stepKey)
+
     return {
       stepKey: s.stepKey,
       stepTitle: s.stepTitle,
@@ -107,6 +161,7 @@ export async function getPipelineRunDetail(projectId: string): Promise<PipelineS
       finishedAt: s.finishedAt?.toISOString() ?? null,
       lastErrorMessage: s.lastErrorMessage,
       usage: stepUsage,
+      subSteps: buildSubSteps(s.stepKey, stepSubEvents),
     }
   })
 

--- a/src/lib/agent-pipeline/pipeline-types.ts
+++ b/src/lib/agent-pipeline/pipeline-types.ts
@@ -41,3 +41,10 @@ export type PipelineLogEntry = {
   model?: string
   detail?: string
 }
+
+export type ResumeContext = {
+  /** Keys of nodes that completed before the pause */
+  completedNodes: string[]
+  /** Serialized PipelineState from the last checkpoint */
+  checkpointState: Record<string, unknown>
+}

--- a/src/lib/agent-pipeline/pipeline-types.ts
+++ b/src/lib/agent-pipeline/pipeline-types.ts
@@ -6,6 +6,14 @@ export type TokenUsage = {
   totalTokens: number
 }
 
+export type SubStepInfo = {
+  key: string
+  title: string
+  status: 'pending' | 'running' | 'completed' | 'failed'
+  startedAt: string | null
+  completedAt: string | null
+}
+
 export type StepInfo = {
   stepKey: string
   stepTitle: string
@@ -15,6 +23,7 @@ export type StepInfo = {
   finishedAt: string | null
   lastErrorMessage: string | null
   usage: TokenUsage
+  subSteps: SubStepInfo[]
 }
 
 export type ActiveTaskInfo = {

--- a/src/lib/run-runtime/graph-executor.ts
+++ b/src/lib/run-runtime/graph-executor.ts
@@ -144,14 +144,18 @@ export async function executePipelineGraph<TState extends GraphExecutorState>(
             attempt,
             state,
             emitSubStep: async (subStepKey: string, status: 'running' | 'completed' | 'failed') => {
-              await createSubStepEvent({
-                runId,
-                projectId,
-                userId,
-                stepKey: node.key,
-                subStepKey,
-                status,
-              })
+              try {
+                await createSubStepEvent({
+                  runId,
+                  projectId,
+                  userId,
+                  stepKey: node.key,
+                  subStepKey,
+                  status,
+                })
+              } catch {
+                // Sub-step events are observational — don't fail the pipeline
+              }
             },
           }),
           node.timeoutMs || 0,

--- a/src/lib/run-runtime/graph-executor.ts
+++ b/src/lib/run-runtime/graph-executor.ts
@@ -1,5 +1,5 @@
 import { normalizeAnyError } from '@/lib/errors/normalize'
-import { buildLeanState, createCheckpoint, getRunById } from './service'
+import { buildLeanState, createCheckpoint, createSubStepEvent, getRunById } from './service'
 import type { StateRef } from './types'
 
 type JsonRecord = Record<string, unknown>
@@ -16,6 +16,7 @@ export type GraphNodeContext<TState extends GraphExecutorState> = {
   nodeKey: string
   attempt: number
   state: TState
+  emitSubStep: (subStepKey: string, status: 'running' | 'completed' | 'failed') => Promise<void>
 }
 
 export type GraphNodeResult = {
@@ -123,6 +124,16 @@ export async function executePipelineGraph<TState extends GraphExecutorState>(
             nodeKey: node.key,
             attempt,
             state,
+            emitSubStep: async (subStepKey: string, status: 'running' | 'completed' | 'failed') => {
+              await createSubStepEvent({
+                runId,
+                projectId,
+                userId,
+                stepKey: node.key,
+                subStepKey,
+                status,
+              })
+            },
           }),
           node.timeoutMs || 0,
         )

--- a/src/lib/run-runtime/graph-executor.ts
+++ b/src/lib/run-runtime/graph-executor.ts
@@ -1,4 +1,5 @@
 import { normalizeAnyError } from '@/lib/errors/normalize'
+import { prisma } from '@/lib/prisma'
 import { buildLeanState, createCheckpoint, createSubStepEvent, getRunById } from './service'
 import type { StateRef } from './types'
 
@@ -48,6 +49,13 @@ export class GraphCancellationError extends Error {
   }
 }
 
+export class PipelinePausedError extends Error {
+  constructor(message = 'pipeline paused by user') {
+    super(message)
+    this.name = 'PipelinePausedError'
+  }
+}
+
 function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
@@ -87,6 +95,17 @@ async function assertRunActive(runId: string, userId: string) {
   }
   if (run.status === 'canceling' || run.status === 'canceled') {
     throw new GraphCancellationError('run canceled')
+  }
+
+  // Check if the associated PipelineRun has been paused
+  if (run.targetType === 'PipelineRun' && run.targetId) {
+    const pipelineRun = await prisma.pipelineRun.findUnique({
+      where: { id: run.targetId },
+      select: { status: true },
+    })
+    if (pipelineRun?.status === 'paused') {
+      throw new PipelinePausedError()
+    }
   }
 }
 
@@ -164,6 +183,9 @@ export async function executePipelineGraph<TState extends GraphExecutorState>(
         break
       } catch (error) {
         if (error instanceof GraphCancellationError) {
+          throw error
+        }
+        if (error instanceof PipelinePausedError) {
           throw error
         }
 

--- a/src/lib/run-runtime/service.ts
+++ b/src/lib/run-runtime/service.ts
@@ -958,18 +958,26 @@ export async function createSubStepEvent(params: {
       ? 'substep.complete'
       : 'substep.error'
 
-  await runtimeClient.graphEvent.create({
-    data: {
-      runId: params.runId,
-      projectId: params.projectId,
-      userId: params.userId,
-      seq: 0,
-      eventType,
-      stepKey: params.stepKey,
-      attempt: null,
-      lane: null,
-      payload: { subStepKey: params.subStepKey },
-    },
+  await runtimeClient.$transaction(async (tx) => {
+    const run = await tx.graphRun.update({
+      where: { id: params.runId },
+      data: { lastSeq: { increment: 1 } },
+      select: { lastSeq: true },
+    })
+
+    await tx.graphEvent.create({
+      data: {
+        runId: params.runId,
+        projectId: params.projectId,
+        userId: params.userId,
+        seq: run.lastSeq,
+        eventType,
+        stepKey: params.stepKey,
+        attempt: null,
+        lane: null,
+        payload: { subStepKey: params.subStepKey },
+      },
+    })
   })
 }
 

--- a/src/lib/run-runtime/service.ts
+++ b/src/lib/run-runtime/service.ts
@@ -944,6 +944,35 @@ export async function listArtifacts(params: {
   return rows.map(mapArtifactRow)
 }
 
+export async function createSubStepEvent(params: {
+  runId: string
+  projectId: string
+  userId: string
+  stepKey: string
+  subStepKey: string
+  status: 'running' | 'completed' | 'failed'
+}) {
+  const eventType = params.status === 'running'
+    ? 'substep.start'
+    : params.status === 'completed'
+      ? 'substep.complete'
+      : 'substep.error'
+
+  await runtimeClient.graphEvent.create({
+    data: {
+      runId: params.runId,
+      projectId: params.projectId,
+      userId: params.userId,
+      seq: 0,
+      eventType,
+      stepKey: params.stepKey,
+      attempt: null,
+      lane: null,
+      payload: { subStepKey: params.subStepKey },
+    },
+  })
+}
+
 export async function retryFailedStep(params: {
   runId: string
   userId: string


### PR DESCRIPTION
## Summary

- **Agent 子步骤透明化**: 每个 Agent 节点定义子步骤（分析/提取/生成等），运行时通过 GraphEvent 记录 substep.start/complete/error 事件，前端实时显示子步骤进度（spinner/checkmark/error）
- **Pipeline 断点续跑**: 新增 pause/resume API，暂停时保存 checkpoint 到 GraphRun，恢复时从上次完成的步骤继续执行而非重头开始
- **Pipeline 失败处理**: 失败时显示错误详情、重试按钮（amber 色，tooltip 提示"从失败位置继续执行"），自动从子步骤事件推断各步骤完成状态
- **顶部栏重构**: 左侧栏合并到顶部横向导航栏，所有按钮统一橙色渐变毛玻璃风格、等高对齐，EpisodeSelector 改为 inline 横向布局
- **Full pipeline flow**: 7-node super-graph（script → art → storyboard → producer → video → voice → assembly）、视频编辑器自动组装、渲染下载

## Key Changes

### Agent Transparency (sub-step progress)
- `agent-identities.ts`: 为每个 agent 定义子步骤
- `graph-executor.ts`: 新增 `emitSubStep` context 方法
- 4 个 agent node 文件: 在关键节点调用 emitSubStep
- `pipeline-status-service.ts`: 从 GraphEvent 构建子步骤状态，无 GraphStep 时从事件推断
- `ExpandableStepCard.tsx`: 渲染子步骤列表（icon + 文字）

### Pipeline Resume
- `pipeline/pause` + `pipeline/resume` API 路由
- `graph-executor.ts`: 检测 pause 信号、抛出 PipelinePausedError
- `super-graph.ts`: checkpoint 保存/恢复逻辑
- `PipelineActionBar.tsx`: 暂停/恢复/重试按钮

### UI Improvements
- `AppShell.tsx`: 新增 `hideSideNav` prop
- `WorkspaceTopActions.tsx`: 全宽顶部栏，左右分区
- `CapsuleNav.tsx`: EpisodeSelector 支持 inline 模式
- `LanguageSwitcher.tsx`: 支持 className prop
- 统一橙色渐变毛玻璃按钮样式

## Test plan
- [ ] 启动 pipeline，观察子步骤实时从 pending → running → completed
- [ ] pipeline 运行中点击暂停，确认状态变为 paused
- [ ] 点击恢复，确认从断点继续而非重头开始
- [ ] pipeline 失败时确认显示错误信息和重试按钮
- [ ] 重试时确认从失败位置继续
- [ ] 顶部栏按钮样式统一、高度对齐
- [ ] EpisodeSelector 下拉功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)